### PR TITLE
continue scanning from the page offset after updating user settings

### DIFF
--- a/SwitchSpeak-iOS/SwitchSpeak-iOS/TouchGrid/TouchSelection.swift
+++ b/SwitchSpeak-iOS/SwitchSpeak-iOS/TouchGrid/TouchSelection.swift
@@ -36,7 +36,7 @@ class TouchSelection {
     
     func refillGrid(withoutPaging:Bool) {
         if withoutPaging {
-            pageOffset = 0 // For now. We will want to just reset to page boundary in the future
+            pageOffset = prevPageOffset
         }
         let settings:UserSettings = GlobalSettings.getUserSettings()
         let cards:[VocabCard] = VocabCardDB.shared!.getCardArray(inTable: settings.tableName, withId: self.screenId)

--- a/SwitchSpeak-iOS/SwitchSpeak-iOS/TouchGrid/TouchSelection.swift
+++ b/SwitchSpeak-iOS/SwitchSpeak-iOS/TouchGrid/TouchSelection.swift
@@ -14,12 +14,14 @@ class TouchSelection {
 	var breadcrumbs = CrumbStack()
     var breadcrumbContainer:UIView?
 	var pageOffset:Int
+	var prevPageOffset: Int
     var screenId:Int64
 	
 	init(breadcrumbContainer:UIView, gridContainer:UIView) {
         self.breadcrumbContainer = breadcrumbContainer
 		self.touchGrid = TouchGrid(gridContainer: gridContainer)
         self.pageOffset = 0
+		self.prevPageOffset = 0
         self.screenId = 0
 		self.refillGrid()
 	}
@@ -57,6 +59,7 @@ class TouchSelection {
 		touchGrid!.resetTouchGrid()
         touchGrid!.fillTouchGrid(cards: gridCards)
 
+		prevPageOffset = pageOffset
         pageOffset = (lastIndex + 1) % cards.count
     }
 	

--- a/SwitchSpeak-iOS/SwitchSpeak-iOS/TouchGrid/TouchSelectionViewController.swift
+++ b/SwitchSpeak-iOS/SwitchSpeak-iOS/TouchGrid/TouchSelectionViewController.swift
@@ -45,12 +45,10 @@ class TouchSelectionViewController: UIViewController {
         shouldRebuildGrid = shouldRebuildGrid || lastSettings!.scanType != newSettings.scanType
         shouldRebuildGrid = shouldRebuildGrid || lastSettings!.fontSize != newSettings.fontSize
         shouldRebuildGrid = shouldRebuildGrid || lastSettings!.scanSpeed != newSettings.scanSpeed
-		
-		touchSelection?.pageOffset = (touchSelection?.prevPageOffset)!
-		
+				
         if shouldRebuildGrid {
             touchSelection!.touchGrid!.buildButtonTree()
-            touchSelection!.refillGrid(withoutPaging: false)
+            touchSelection!.refillGrid(withoutPaging: true)
         }
       
         lastSettings = newSettings

--- a/SwitchSpeak-iOS/SwitchSpeak-iOS/TouchGrid/TouchSelectionViewController.swift
+++ b/SwitchSpeak-iOS/SwitchSpeak-iOS/TouchGrid/TouchSelectionViewController.swift
@@ -45,7 +45,7 @@ class TouchSelectionViewController: UIViewController {
         shouldRebuildGrid = shouldRebuildGrid || lastSettings!.scanType != newSettings.scanType
         shouldRebuildGrid = shouldRebuildGrid || lastSettings!.fontSize != newSettings.fontSize
         shouldRebuildGrid = shouldRebuildGrid || lastSettings!.scanSpeed != newSettings.scanSpeed
-				
+		
         if shouldRebuildGrid {
             touchSelection!.touchGrid!.buildButtonTree()
             touchSelection!.refillGrid(withoutPaging: true)

--- a/SwitchSpeak-iOS/SwitchSpeak-iOS/TouchGrid/TouchSelectionViewController.swift
+++ b/SwitchSpeak-iOS/SwitchSpeak-iOS/TouchGrid/TouchSelectionViewController.swift
@@ -45,7 +45,7 @@ class TouchSelectionViewController: UIViewController {
         shouldRebuildGrid = shouldRebuildGrid || lastSettings!.scanType != newSettings.scanType
         shouldRebuildGrid = shouldRebuildGrid || lastSettings!.fontSize != newSettings.fontSize
         shouldRebuildGrid = shouldRebuildGrid || lastSettings!.scanSpeed != newSettings.scanSpeed
-		
+	
         if shouldRebuildGrid {
             touchSelection!.touchGrid!.buildButtonTree()
             touchSelection!.refillGrid(withoutPaging: true)

--- a/SwitchSpeak-iOS/SwitchSpeak-iOS/TouchGrid/TouchSelectionViewController.swift
+++ b/SwitchSpeak-iOS/SwitchSpeak-iOS/TouchGrid/TouchSelectionViewController.swift
@@ -45,10 +45,12 @@ class TouchSelectionViewController: UIViewController {
         shouldRebuildGrid = shouldRebuildGrid || lastSettings!.scanType != newSettings.scanType
         shouldRebuildGrid = shouldRebuildGrid || lastSettings!.fontSize != newSettings.fontSize
         shouldRebuildGrid = shouldRebuildGrid || lastSettings!.scanSpeed != newSettings.scanSpeed
-        
+		
+		touchSelection?.pageOffset = (touchSelection?.prevPageOffset)!
+		
         if shouldRebuildGrid {
             touchSelection!.touchGrid!.buildButtonTree()
-            touchSelection!.refillGrid(withoutPaging: true)
+            touchSelection!.refillGrid(withoutPaging: false)
         }
       
         lastSettings = newSettings


### PR DESCRIPTION
* Added a new member `prevPageOffset` to the `TouchSelection` class to keep track of the previous page offset.
* In each call of the `registerUserSettings` function, we set the `pageOffset` variable to `prevPageOffset` and hence continue scanning from the previously unselected set of cards.